### PR TITLE
chore: add Vercel deployment config

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -35,15 +35,8 @@ hugo
 - The output will be in the `public/` directory, ready for deployment.
 - Make sure to commit the latest `static/css/style.css` if your deployment pipeline does not run the Tailwind build step automatically.
 
-#### CI / Automated Production Builds
-If building in CI, add a pre-build step:
-```sh
-pnpm install --frozen-lockfile
-pnpm run tailwind:build
-hugo
-```
-- Ensure Node.js, PNPM, and Hugo are available in your CI environment.
-- You can cache `node_modules` for faster builds.
+#### Production Deployment
+Production deploys are handled by Vercel via native Git integration — every push to `main` triggers an automatic build. Build settings live in `vercel.json` (framework, install/build commands, output directory). The Hugo version is pinned via a `HUGO_VERSION` environment variable in the Vercel project settings. No CI workflow to maintain in this repo.
 
 ## More Information
 - See the main project README for overall project details.

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "hugo",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm run tailwind:build && hugo --gc --minify",
+  "outputDirectory": "public"
+}


### PR DESCRIPTION
## Summary
- Adds `website/vercel.json` so Vercel's native Git integration can build the Hugo + Tailwind static site with the project's Root Directory set to `website`.
- Updates `website/README.md` to document Vercel as the deploy pipeline.
- **Keeps** `.github/workflows/gh-pages.yml` — GitHub Pages continues to serve `cf-purge.app` until a follow-up PR cuts DNS over to Vercel.

## Manual steps (Vercel dashboard, after merge)
1. Add new project → import `Dzhuneyt/cf-purge`.
2. Root Directory: `website`.
3. Env var: `HUGO_VERSION` = concrete version (e.g. `0.140.2`) for build reproducibility.
4. Deploy; note the `*.vercel.app` URL.
5. Do **not** add the `cf-purge.app` custom domain yet — deferred to the DNS cutover PR.

## Test plan
- [ ] Vercel build log shows `pnpm install` → `pnpm run tailwind:build` → `hugo` → success.
- [ ] `*.vercel.app` preview: homepage loads with Tailwind styles, internal links navigate, no 404s on CSS/images.
- [ ] DevTools Network tab: no hardcoded `https://cf-purge.app` absolute URLs pointing off the preview domain (if broken, we add `--baseURL "$VERCEL_URL"` to the build command).
- [ ] Trivial commit to `main` post-merge auto-triggers a new Vercel deploy.
- [ ] `cf-purge.app` still resolves via GitHub Pages during this phase — untouched.

## Out of scope (follow-up PR)
- DNS cutover of `cf-purge.app` from GitHub Pages → Vercel.
- Deleting `.github/workflows/gh-pages.yml` and the `gh-pages` branch.
- Disabling GitHub Pages in repo Settings.